### PR TITLE
Custom data map data function was defined to be sin(pi-x)

### DIFF
--- a/machine_learning/custom_feature_map.ipynb
+++ b/machine_learning/custom_feature_map.ipynb
@@ -231,7 +231,7 @@
     "    Returns:\n",
     "        double: the mapped value\n",
     "    \"\"\"\n",
-    "    coeff = x[0] if len(x) == 1 else functools.reduce(lambda m, n: m * n, np.pi - x)\n",
+    "    coeff = x[0] if len(x) == 1 else functools.reduce(lambda m, n: m * n, np.sin(np.pi - x))\n",
     "    return coeff"
    ]
   },


### PR DESCRIPTION
Sin() was missing.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.


✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Custom data function phi(x) was defined as shown in the image below. But in the code Sin() was missing
<img width="824" alt="gd" src="https://user-images.githubusercontent.com/53303239/92777786-29de6d00-f3be-11ea-9c89-5b3a88f5287e.png">


### Details and comments


