### PR TITLE
Adding missing np.sin() in Custom Feature Maps notebook

### DIFF
--- a/machine_learning/custom_feature_map.ipynb
+++ b/machine_learning/custom_feature_map.ipynb
@@ -231,7 +231,7 @@
     "    Returns:\n",
     "        double: the mapped value\n",
     "    \"\"\"\n",
-    "    coeff = x[0] if len(x) == 1 else functools.reduce(lambda m, n: m * n, np.pi - x)\n",
+    "    coeff = x[0] if len(x) == 1 else functools.reduce(lambda m, n: m * n, np.sin(np.pi - x))\n",
     "    return coeff"
    ]
   },
@@ -509,7 +509,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixed a tiny error regarding a missing sine function.


### Details and comments
In the "custom_feature_map" notebook, in `In[5]`, the last argument to the `functools.reduce(lambda m, n: m * n, np.pi - x)` was to be changed to `functools.reduce(lambda m, n: m * n, np.sin(np.pi - x))` as per the required mapping. I have made the change, so please review and merge :))

